### PR TITLE
Implement ML feedback loop for PP metadata corrections

### DIFF
--- a/.coord/PROJECT-CONTEXT.md
+++ b/.coord/PROJECT-CONTEXT.md
@@ -5,7 +5,7 @@
 ## 🌐 Ecosystem Position
 
 **For complete pipeline positioning (where we fit in EAV production workflow):**
-→ **[`.coord/ECOSYSTEM-POSITION.md`](.coord/ECOSYSTEM-POSITION.md)**
+→ **[`ECOSYSTEM-POSITION.md`](ECOSYSTEM-POSITION.md)**
 
 **Pipeline Step:** 7 of 10 | **Role:** Ingestion gateway (raw footage → structured metadata) | **Upstream:** Ingest Assistant | **Downstream:** Edit Web
 
@@ -19,16 +19,30 @@
 
 ## Tech Stack
 - **Framework:** Adobe CEP APIs
-- **Frontend:** HTML, CSS, JavaScript/TypeScript
-- **Integration:** Premiere Pro Project Panel metadata
-- **Communication:** CSInterface (CEP ↔ Premiere Pro)
+- **Frontend:** HTML, CSS, JavaScript
+- **ExtendScript:** ES3 (Premiere Pro scripting layer)
+- **XMP Metadata:** Direct XMP read/write via item.getXMPMetadata() / item.setXMPMetadata()
+- **Communication:** CSInterface (CEP ↔ ExtendScript)
 
 ## Key Features
-- **Metadata Tagging:** Location, Subject, Action, Shot Type fields
-- **Structured Naming:** `{location}-{subject}-{action}-{shotType}` format
-- **XMP Integration:** Read pre-tagged metadata from Ingest Assistant
-- **Premiere Pro Fields:** Write to Name, Tape Name, Description, Shot
-- **Batch Operations:** Tag multiple clips simultaneously
+
+### Metadata Tagging & XMP Integration
+- **Structured Fields:** Location, Subject, Action, Shot Type
+- **Naming Convention:** {location}-{subject}-{action}-{shotType} format
+- **XMP Read/Write:**
+  - xmpDM:shotName → Combined name (maps to PP Shot field)
+  - xmpDM:LogComment → Structured key=value pairs (e.g., location=kitchen, subject=oven, shotType=ESTAB)
+  - dc:description → Keywords/tags (Dublin Core standard)
+- **IA Compatibility:** Reads/writes same XMP fields as Ingest Assistant (bidirectional workflow)
+- **Premiere Pro Integration:** Updates clip Name in project panel
+
+### ML Feedback Loop
+- **PP Edits Tracking:** Writes .ingest-metadata-pp.json to original media folder
+- **Side-by-side Comparison:** Lives alongside .ingest-metadata.json (IA original)
+- **Schema Compatibility:** Identical JSON format for easy diffing
+- **ML Training:** Compare AI predictions vs. human corrections
+- **Audit Trail:** Tracks modifiedAt, modifiedBy for each edit
+- **Documentation:** See docs/002-DOC-ML-FEEDBACK-LOOP.md
 
 ## Current State
 
@@ -56,8 +70,9 @@
 - **Ingest Assistant:** `/Volumes/HestAI-Projects/ingest-assistant/.coord/ECOSYSTEM-POSITION.md`
 
 **This Project:**
-- **Ecosystem Position:** `.coord/ECOSYSTEM-POSITION.md` (detailed pipeline positioning)
+- **Ecosystem Position:** ECOSYSTEM-POSITION.md (detailed pipeline positioning)
+- **ML Feedback Loop:** docs/002-DOC-ML-FEEDBACK-LOOP.md
 
 ---
 
-**LAST UPDATED:** 2025-11-10
+**LAST UPDATED:** 2025-11-12

--- a/.coord/docs/002-DOC-ML-FEEDBACK-LOOP.md
+++ b/.coord/docs/002-DOC-ML-FEEDBACK-LOOP.md
@@ -1,0 +1,281 @@
+# ML Feedback Loop - PP Edits Tracking
+
+**Purpose:** Track human corrections made in Premiere Pro to improve AI metadata generation accuracy.
+
+**Status:** ✅ Implemented (2025-11-12)
+
+---
+
+## Overview
+
+The CEP panel creates a **parallel JSON file** alongside the original Ingest Assistant metadata to track human edits. This enables:
+
+1. **Accuracy measurement** - Compare AI predictions vs. human corrections
+2. **ML training data** - Feed corrections back to improve AI prompts
+3. **Quality metrics** - Track which fields/categories need improvement
+4. **Audit trail** - Know when/who made changes
+
+---
+
+## File Structure
+
+```
+/Volumes/EAV_Video_RAW/Berkeley/EAV036/shoot1-20251103/
+├── EA001932.MOV                       ← Media file
+├── .ingest-metadata.json              ← AI-generated (Ingest Assistant)
+└── .ingest-metadata-pp.json           ← Human-corrected (CEP Panel)
+```
+
+Both JSON files use **identical schema** for easy comparison.
+
+---
+
+## JSON Schema (v2.0)
+
+**File:** `.ingest-metadata-pp.json`
+
+```json
+{
+  "_schema": "2.0",
+  "EA001932": {
+    // === File Identification ===
+    "id": "EA001932",
+    "originalFilename": "EA001932.MOV",
+    "currentFilename": "EA001932.MOV",
+    "filePath": "/Volumes/EAV_Video_RAW/Berkeley/EAV036/shoot1-20251103/EA001932.MOV",
+    "extension": ".MOV",
+    "fileType": "video",
+
+    // === Core Metadata ===
+    "mainName": "hallway-front-door-safety-chain-CU",
+    "keywords": ["door", "chain", "lock"],
+
+    // === Structured Components ===
+    "location": "hallway",
+    "subject": "front-door",
+    "action": "safety-chain",
+    "shotType": "CU",
+
+    // === Processing State ===
+    "processedByAI": true,
+
+    // === Audit Trail ===
+    "createdAt": "2025-11-12T10:00:00.000Z",
+    "createdBy": "ingest-assistant",
+    "modifiedAt": "2025-11-12T15:30:00.000Z",
+    "modifiedBy": "cep-panel",
+    "version": "1.0.0"
+  }
+}
+```
+
+### Key Fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `processedByAI` | Preserved from IA | Indicates if AI was used |
+| `createdAt` | Preserved from IA | Original creation timestamp |
+| `createdBy` | Preserved from IA | Always `"ingest-assistant"` |
+| `modifiedAt` | Updated by CEP | Timestamp of PP edit |
+| `modifiedBy` | Set by CEP | Always `"cep-panel"` |
+
+---
+
+## Implementation
+
+### **CEP Panel (jsx/host.jsx:553-737)**
+
+When "Apply to Premiere" is clicked:
+
+1. **Read original IA JSON** (`.ingest-metadata.json`)
+   - Preserve `processedByAI`, `createdAt`, `createdBy`
+
+2. **Build PP edits entry**
+   - Update structured fields (`location`, `subject`, `action`, `shotType`)
+   - Set `modifiedAt` to current timestamp
+   - Set `modifiedBy` to `"cep-panel"`
+
+3. **Write to PP JSON** (`.ingest-metadata-pp.json`)
+   - Merge with existing entries (supports multiple clips per folder)
+   - Create file if doesn't exist
+
+4. **Log success/failure** to diagnostics panel
+
+### **Error Handling:**
+
+- If `.ingest-metadata.json` doesn't exist → Still writes PP JSON (IA fields blank)
+- If media path unavailable → Skips JSON write, logs warning
+- If file write fails → Logs error to diagnostics panel, doesn't block XMP write
+
+---
+
+## Comparison Workflow
+
+### **Step 1: Compare JSONs**
+
+```bash
+#!/bin/bash
+# scripts/compare-metadata.sh
+
+FOLDER="/Volumes/EAV_Video_RAW/Berkeley/EAV036/shoot1-20251103"
+IA_JSON="$FOLDER/.ingest-metadata.json"
+PP_JSON="$FOLDER/.ingest-metadata-pp.json"
+OUTPUT="metadata-diff-$(date +%Y%m%d-%H%M%S).json"
+
+jq -s '
+  .[0] as $ia | .[1] as $pp |
+  ($ia | keys_unsorted | .[1:]) as $ids |  # Skip _schema key
+  $ids | map({
+    id: .,
+    ai_metadata: $ia[.],
+    pp_metadata: $pp[.],
+    changes: {
+      location: (if ($ia[.].location != $pp[.].location) then
+        {ai: $ia[.].location, pp: $pp[.].location} else null end),
+      subject: (if ($ia[.].subject != $pp[.].subject) then
+        {ai: $ia[.].subject, pp: $pp[.].subject} else null end),
+      action: (if ($ia[.].action != $pp[.].action) then
+        {ai: $ia[.].action, pp: $pp[.].action} else null end),
+      shotType: (if ($ia[.].shotType != $pp[.].shotType) then
+        {ai: $ia[.].shotType, pp: $pp[.].shotType} else null end),
+      keywords: (if ($ia[.].keywords != $pp[.].keywords) then
+        {ai: $ia[.].keywords, pp: $pp[.].keywords} else null end)
+    }
+  }) | map(select(
+    .changes.location != null or
+    .changes.subject != null or
+    .changes.action != null or
+    .changes.shotType != null or
+    .changes.keywords != null
+  ))
+' "$IA_JSON" "$PP_JSON" > "$OUTPUT"
+
+echo "Diff report generated: $OUTPUT"
+```
+
+**Output Example:**
+
+```json
+[
+  {
+    "id": "EA001932",
+    "ai_metadata": { "location": "hallway", "subject": "door", ... },
+    "pp_metadata": { "location": "hallway", "subject": "front-door", ... },
+    "changes": {
+      "subject": {
+        "ai": "door",
+        "pp": "front-door"
+      }
+    }
+  }
+]
+```
+
+---
+
+### **Step 2: Accuracy Metrics**
+
+```bash
+#!/bin/bash
+# scripts/calculate-accuracy.sh
+
+DIFF_FILE="metadata-diff-*.json"
+
+jq '
+  {
+    total_files: length,
+    total_changes: (map(.changes | to_entries | length) | add),
+    changes_by_field: (
+      map(.changes | to_entries | map(.key)) | flatten |
+      group_by(.) |
+      map({(.[0]): length}) |
+      add
+    ),
+    accuracy: (
+      (length - (map(.changes | to_entries | length) | add)) / length * 100
+    )
+  }
+' "$DIFF_FILE"
+```
+
+**Output Example:**
+
+```json
+{
+  "total_files": 120,
+  "total_changes": 15,
+  "changes_by_field": {
+    "subject": 8,
+    "location": 4,
+    "shotType": 3
+  },
+  "accuracy": 87.5
+}
+```
+
+---
+
+### **Step 3: ML Training Data Generation**
+
+**Format for AI prompt improvement:**
+
+```json
+{
+  "training_examples": [
+    {
+      "image_or_video_description": "[extracted from file or XMP]",
+      "incorrect_prediction": {
+        "location": "hallway",
+        "subject": "door"
+      },
+      "correct_classification": {
+        "location": "hallway",
+        "subject": "front-door"
+      },
+      "correction_reason": "Subject should be more specific (front-door vs. generic door)"
+    }
+  ]
+}
+```
+
+---
+
+## Testing Checklist
+
+- [x] PP edits JSON created when "Apply to Premiere" clicked
+- [x] File written to original media folder (not PP project folder)
+- [x] Schema matches IA JSON format (v2.0)
+- [x] Preserves `processedByAI`, `createdAt`, `createdBy` from IA
+- [x] Updates `modifiedAt`, `modifiedBy` with PP values
+- [x] Multiple clips in same folder accumulate in single JSON
+- [x] Diagnostics panel shows success/failure message
+- [ ] Comparison script generates diff report
+- [ ] Accuracy metrics script calculates correction rate
+- [ ] ML training data format validated
+
+---
+
+## Future Enhancements
+
+### **Short-term:**
+- [ ] Network sync queue for offline editing scenarios
+- [ ] Bulk comparison script (process entire project)
+- [ ] Web dashboard for accuracy metrics
+
+### **Long-term:**
+- [ ] Automated prompt refinement based on corrections
+- [ ] Per-category accuracy tracking (e.g., kitchen vs. bathroom)
+- [ ] Human-in-the-loop training pipeline integration
+
+---
+
+## References
+
+- **Implementation:** `jsx/host.jsx:553-737`
+- **Schema Documentation:** `CLAUDE.md` (ML Feedback Loop section)
+- **Related:** `../ingest-assistant/.coord/docs/000001-DOC-METADATA-STRATEGY-SHARED.md`
+
+---
+
+**Last Updated:** 2025-11-12
+**Author:** Claude Code (eav-cep-assist session)

--- a/scripts/compare-metadata.sh
+++ b/scripts/compare-metadata.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# compare-metadata.sh - Compare AI-generated vs human-corrected metadata
+#
+# Usage:
+#   ./scripts/compare-metadata.sh /path/to/media/folder
+#   ./scripts/compare-metadata.sh /Volumes/EAV_Video_RAW/Berkeley/EAV036/shoot1-20251103
+#
+# Output:
+#   Generates metadata-diff-{timestamp}.json with corrections for ML training
+
+set -euo pipefail
+
+# Check arguments
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 /path/to/media/folder"
+    echo ""
+    echo "Example:"
+    echo "  $0 /Volumes/EAV_Video_RAW/Berkeley/EAV036/shoot1-20251103"
+    exit 1
+fi
+
+FOLDER="$1"
+IA_JSON="$FOLDER/.ingest-metadata.json"
+PP_JSON="$FOLDER/.ingest-metadata-pp.json"
+OUTPUT="metadata-diff-$(date +%Y%m%d-%H%M%S).json"
+
+# Validate files exist
+if [ ! -f "$IA_JSON" ]; then
+    echo "Error: IA metadata file not found: $IA_JSON"
+    exit 1
+fi
+
+if [ ! -f "$PP_JSON" ]; then
+    echo "Error: PP edits file not found: $PP_JSON"
+    echo "No human corrections have been made yet."
+    exit 1
+fi
+
+# Generate diff report
+jq -s '
+  .[0] as $ia | .[1] as $pp |
+
+  # Get all clip IDs (skip _schema key)
+  ($ia | keys_unsorted | map(select(. != "_schema"))) as $ids |
+
+  # Compare each clip
+  $ids | map({
+    id: .,
+    ai_metadata: {
+      location: $ia[.].location,
+      subject: $ia[.].subject,
+      action: $ia[.].action,
+      shotType: $ia[.].shotType,
+      keywords: $ia[.].keywords
+    },
+    pp_metadata: {
+      location: $pp[.].location,
+      subject: $pp[.].subject,
+      action: $pp[.].action,
+      shotType: $pp[.].shotType,
+      keywords: $pp[.].keywords
+    },
+    changes: {
+      location: (
+        if ($ia[.].location != $pp[.].location) then
+          {ai: $ia[.].location, pp: $pp[.].location}
+        else null end
+      ),
+      subject: (
+        if ($ia[.].subject != $pp[.].subject) then
+          {ai: $ia[.].subject, pp: $pp[.].subject}
+        else null end
+      ),
+      action: (
+        if ($ia[.].action != $pp[.].action) then
+          {ai: $ia[.].action, pp: $pp[.].action}
+        else null end
+      ),
+      shotType: (
+        if ($ia[.].shotType != $pp[.].shotType) then
+          {ai: $ia[.].shotType, pp: $pp[.].shotType}
+        else null end
+      ),
+      keywords: (
+        if ($ia[.].keywords != $pp[.].keywords) then
+          {ai: $ia[.].keywords, pp: $pp[.].keywords}
+        else null end
+      )
+    },
+    audit: {
+      processedByAI: $ia[.].processedByAI,
+      createdAt: $ia[.].createdAt,
+      modifiedAt: $pp[.].modifiedAt
+    }
+  }) |
+
+  # Filter to only clips with changes
+  map(select(
+    .changes.location != null or
+    .changes.subject != null or
+    .changes.action != null or
+    .changes.shotType != null or
+    .changes.keywords != null
+  ))
+' "$IA_JSON" "$PP_JSON" > "$OUTPUT"
+
+# Generate summary
+TOTAL_CHANGES=$(jq 'length' "$OUTPUT")
+
+if [ "$TOTAL_CHANGES" -eq 0 ]; then
+    echo "✓ No corrections found - AI predictions match human review!"
+    rm "$OUTPUT"
+    exit 0
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📊 Metadata Comparison Report"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Folder: $FOLDER"
+echo "Clips with corrections: $TOTAL_CHANGES"
+echo ""
+
+# Show changes by field
+echo "Changes by field:"
+jq -r '
+  map(.changes | to_entries | map(select(.value != null) | .key)) |
+  flatten |
+  group_by(.) |
+  map("  \(.[0]): \(length) corrections") |
+  .[]
+' "$OUTPUT"
+
+echo ""
+echo "Diff report saved: $OUTPUT"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Adds documentation and scripts for tracking human corrections to AI-generated metadata in Premiere Pro. Updates the metadata strategy to use the correct XMP field (xmpDM:LogComment) for structured metadata, and writes a parallel .ingest-metadata-pp.json file for each media folder. Includes a Bash script (compare-metadata.sh) to compare AI and human metadata for ML training, and updates documentation to describe the workflow and schema.