### PR TITLE
fix: recognize Premiere Pro 2025/2026 in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ fi
 # Step 1: Check Premiere Pro version
 echo "Step 1: Checking Premiere Pro installation..."
 PP_PATHS=(
+    "/Applications/Adobe Premiere Pro 2026"
+    "/Applications/Adobe Premiere Pro 2025"
     "/Applications/Adobe Premiere Pro 2024"
     "/Applications/Adobe Premiere Pro 2023"
     "/Applications/Adobe Premiere Pro 2022"
@@ -37,7 +39,7 @@ for PP_PATH in "${PP_PATHS[@]}"; do
 
         # Determine CSXS version
         case "$PP_VERSION" in
-            *2024*|*2023*)
+            *2026*|*2025*|*2024*|*2023*)
                 CSXS_VERSION="12"
                 ;;
             *2022*|*2021*)


### PR DESCRIPTION
## Summary
- `install.sh` only checked for Premiere Pro 2020–2024, so on a machine with PP 2026 installed it failed with "Premiere Pro not found in /Applications/" even though PP 2026 is present.
- PP 2026 uses the same CSXS 12 debug-mode domain as 2023/2024 (verified via `com.adobe.CSXS.12` already registered on the test machine), so this adds 2025/2026 to the detected install paths and maps them to CSXS 12.

## Test plan
- [x] Ran `./install.sh` on a machine with only Premiere Pro 2026 installed — now detects it, enables `PlayerDebugMode` for CSXS 12, and deploys both panels successfully.
- [ ] Confirm panels load correctly inside Premiere Pro 2026 after restart (manual, in Premiere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `install.sh` to detect and support Adobe Premiere Pro 2025 and 2026 by adding their install paths and mapping them to CSXS 12 so debug mode and panel deployment work.

<sup>Written for commit 4e32c5cd9d9b823d6fd2e10616fb560ec88d26af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/eav-cep-assist/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

